### PR TITLE
PostgreSQL: versions & platform support updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Required:
 - `postgresql_version`: The PostgreSQL major version, e.g. `10`, `11`, `12`, `13`, `14`
 
 Optional:
-- `postgresql_package_version`: The PostgreSQL full version, ignored on Ubuntu, e.g. `9.6.13`
+- `postgresql_package_version`: The PostgreSQL full version, ignored on Ubuntu, e.g. `12.11`
 
 
 Example Playbook
@@ -27,7 +27,7 @@ Example Playbook
     - hosts: localhost
       roles:
       - role: ome.postgresql_client
-        postgresql_version: "10"
+        postgresql_version: "12"
 
 
 Author Information

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Role Variables
 --------------
 
 Required:
-- `postgresql_version`: The PostgreSQL major version, e.g. `9.6`, `10`, `11`.
+- `postgresql_version`: The PostgreSQL major version, e.g. `10`, `11`, `12`, `13`, `14`
 
 Optional:
 - `postgresql_package_version`: The PostgreSQL full version, ignored on Ubuntu, e.g. `9.6.13`

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
+        - focal
   role_name: postgresql_client
   galaxy_tags: ['postgresql', 'database']
 

--- a/molecule/centos7/molecule.yml
+++ b/molecule/centos7/molecule.yml
@@ -6,6 +6,10 @@ driver:
 lint:
   name: yamllint
 platforms:
+  - name: postgresql_exact
+    image: centos:7
+    groups:
+      - exactversion
   - name: postgresql10
     image: centos:7
   - name: postgresql11
@@ -22,6 +26,9 @@ provisioner:
     name: ansible-lint
   inventory:
     host_vars:
+      postgresql_exact:
+        postgresql_version: "12"
+        postgresql_package_version: "12.11"
       postgresql10:
         postgresql_version: "10"
       postgresql11:

--- a/molecule/centos7/molecule.yml
+++ b/molecule/centos7/molecule.yml
@@ -6,10 +6,6 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: postgresql96
-    image: centos:7
-    groups:
-      - exactversion
   - name: postgresql10
     image: centos:7
   - name: postgresql11
@@ -26,9 +22,6 @@ provisioner:
     name: ansible-lint
   inventory:
     host_vars:
-      postgresql96:
-        postgresql_version: "9.6"
-        postgresql_package_version: "9.6.13"
       postgresql10:
         postgresql_version: "10"
       postgresql11:

--- a/molecule/centos7/molecule.yml
+++ b/molecule/centos7/molecule.yml
@@ -16,6 +16,10 @@ platforms:
     image: centos:7
   - name: postgresql12
     image: centos:7
+  - name: postgresql13
+    image: centos:7
+  - name: postgresql14
+    image: centos:7
 provisioner:
   name: ansible
   lint:
@@ -31,6 +35,10 @@ provisioner:
         postgresql_version: "11"
       postgresql12:
         postgresql_version: "12"
+      postgresql13:
+        postgresql_version: "13"
+      postgresql14:
+        postgresql_version: "14"
   playbooks:
     converge: ../resources/playbook.yml
 scenario:

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -5,17 +5,8 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def get_version(hostname):
-    ver_lookup = {
-        "postgresql96": "9.6",
-        "postgresql10": "10",
-        "postgresql11": "11",
-        "postgresql12": "12",
-    }
-    return ver_lookup[hostname]
-
-
 def test_psql_version(host):
-    ver = get_version(host.backend.get_hostname())
+    variables = host.ansible.get_variables()
+    version = variables["postgresql_version"]
     out = host.check_output('psql --version')
-    assert out.startswith('psql (PostgreSQL) {}.'.format(ver))
+    assert out.startswith('psql (PostgreSQL) {}.'.format(version))

--- a/molecule/resources/tests/test_exactversion.py
+++ b/molecule/resources/tests/test_exactversion.py
@@ -7,4 +7,4 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_psql_version(host):
     out = host.check_output('psql --version')
-    assert out == 'psql (PostgreSQL) 9.6.13'
+    assert out == 'psql (PostgreSQL) 12.11'

--- a/molecule/ubuntu1804/molecule.yml
+++ b/molecule/ubuntu1804/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: postgresql96
-    image: ubuntu:18.04
   - name: postgresql10
     image: ubuntu:18.04
   - name: postgresql11
@@ -24,8 +22,6 @@ provisioner:
     name: ansible-lint
   inventory:
     host_vars:
-      postgresql96:
-        postgresql_version: "9.6"
       postgresql10:
         postgresql_version: "10"
       postgresql11:

--- a/molecule/ubuntu1804/molecule.yml
+++ b/molecule/ubuntu1804/molecule.yml
@@ -14,6 +14,10 @@ platforms:
     image: ubuntu:18.04
   - name: postgresql12
     image: ubuntu:18.04
+  - name: postgresql13
+    image: ubuntu:18.04
+  - name: postgresql14
+    image: ubuntu:18.04
 provisioner:
   name: ansible
   lint:
@@ -28,6 +32,10 @@ provisioner:
         postgresql_version: "11"
       postgresql12:
         postgresql_version: "12"
+      postgresql13:
+        postgresql_version: "13"
+      postgresql14:
+        postgresql_version: "14"
   playbooks:
     converge: ../resources/playbook.yml
 scenario:

--- a/molecule/ubuntu2004/Dockerfile.j2
+++ b/molecule/ubuntu2004/Dockerfile.j2
@@ -1,0 +1,1 @@
+../resources/Dockerfile.j2

--- a/molecule/ubuntu2004/molecule.yml
+++ b/molecule/ubuntu2004/molecule.yml
@@ -6,8 +6,6 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: postgresql96
-    image: ubuntu:20.04
   - name: postgresql10
     image: ubuntu:20.04
   - name: postgresql11
@@ -24,8 +22,6 @@ provisioner:
     name: ansible-lint
   inventory:
     host_vars:
-      postgresql96:
-        postgresql_version: "9.6"
       postgresql10:
         postgresql_version: "10"
       postgresql11:

--- a/molecule/ubuntu2004/molecule.yml
+++ b/molecule/ubuntu2004/molecule.yml
@@ -1,0 +1,47 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: postgresql96
+    image: ubuntu:20.04
+  - name: postgresql10
+    image: ubuntu:20.04
+  - name: postgresql11
+    image: ubuntu:20.04
+  - name: postgresql12
+    image: ubuntu:20.04
+  - name: postgresql13
+    image: ubuntu:20.04
+  - name: postgresql14
+    image: ubuntu:20.04
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  inventory:
+    host_vars:
+      postgresql96:
+        postgresql_version: "9.6"
+      postgresql10:
+        postgresql_version: "10"
+      postgresql11:
+        postgresql_version: "11"
+      postgresql12:
+        postgresql_version: "12"
+      postgresql13:
+        postgresql_version: "13"
+      postgresql14:
+        postgresql_version: "14"
+  playbooks:
+    converge: ../resources/playbook.yml
+scenario:
+  name: ubuntu2004
+verifier:
+  name: testinfra
+  directory: ../resources/tests/
+  lint:
+    name: flake8

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -11,7 +11,7 @@
   become: true
   yum:
     name: >-
-      {{ postgresql_distribution_redhat[postgresql_version].basename }}{{
+      postgresql{{ postgresql_version }}{{
         (postgresql_package_version | length > 0) |
         ternary('-' + postgresql_package_version, '')
       }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,3 +19,11 @@ postgresql_distribution_redhat:
     repo: pgdg12
     basename: postgresql12
     setup: postgresql-12-setup
+  "13":
+    repo: pgdg13
+    basename: postgresql13
+    setup: postgresql-13-setup
+  "14":
+    repo: pgdg14
+    basename: postgresql14
+    setup: postgresql-14-setup

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 # vars file for ome.postgresql_client
 
+# DEPRECATED
 # This variable includes information used by the postgresql (server) role
 postgresql_distribution_redhat:
   "9.6":


### PR DESCRIPTION
Summary of changes:

- PSQL 9.6 (EOL) is removed from the Molecule tests and the README. In particular,  this should fix the failing scheduled build as the RedHat PSQL 9.6 packages have been fully dropped
- Molecule scenarios are added under Ubuntu 20.04 and `focal` is added as a supported environment to the Ansible Galaxy metadata file
- Molecule tests are added for PSQL 13 and 14 under supported platforms
- as per the removal of PSQL 9.6, the `postgresql_distribution_redhat` variable is updated but deprecated and the installation in `tasks/redhat.yml` is simplified.

The last modification means this role should be forward compatinle with upcoming major releases of PSQL like 15 without requiring any update to the role variable. A follow-up PR will be opened against `ome.postgresql` to remove the dependency on the deprecated variable once this role is released.

Proposed tag: `0.2.0`