### PR TITLE
Update PGDG RPM key and remove PSQL 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Role Variables
 --------------
 
 Required:
-- `postgresql_version`: The PostgreSQL major version, e.g. `11`, `12`, `13`, `14`
+- `postgresql_version`: The PostgreSQL major version, e.g. `12`, `13`, `14`
 
 Optional:
 - `postgresql_package_version`: The PostgreSQL full version, ignored on Ubuntu, e.g. `12.11`

--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -8,8 +8,6 @@ lint: |
     ansible-lint
     flake8
 platforms:
-  - name: postgresql11
-    image: rockylinux:9
   - name: postgresql12
     image: rockylinux:9
   - name: postgresql13
@@ -23,8 +21,6 @@ provisioner:
   inventory:
     host_vars:
       postgresql_exact:
-      postgresql11:
-        postgresql_version: "11"
       postgresql12:
         postgresql_version: "12"
       postgresql13:

--- a/molecule/ubuntu2204/molecule.yml
+++ b/molecule/ubuntu2204/molecule.yml
@@ -8,8 +8,6 @@ lint: |
     ansible-lint
     flake8
 platforms:
-  - name: postgresql11
-    image: ubuntu:22.04
   - name: postgresql12
     image: ubuntu:22.04
   - name: postgresql13
@@ -22,8 +20,6 @@ provisioner:
     name: ansible-lint
   inventory:
     host_vars:
-      postgresql11:
-        postgresql_version: "11"
       postgresql12:
         postgresql_version: "12"
       postgresql13:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -2,7 +2,7 @@
 - name: Import a key for postgres
   ansible.builtin.rpm_key:
     state: present
-    key:  https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    key:  https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL
 
 - name: postgres | setup dnf repository
   become: true


### PR DESCRIPTION
As explained https://yum.postgresql.org/news/pgdg-rpm-repo-gpg-key-update/ new RPM keys have been generated and the old URL is now 404. This is leading this role as well as all downstream ones to fail on RedHat systems - see for instance. https://github.com/ome/ansible-role-postgresql/actions/runs/7440864235/job/20242331661

Also updates the range of tested PostgreSQL versions as PSQL 11 is now EOL since November 2023 and the `postgresql11` is no longer available from the RPM repositories.
