### PR TITLE
use dash instead of underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Postgresql Client
 =================
 
 [![Actions Status](https://github.com/ome/ansible-role-postgresql-client/workflows/Molecule/badge.svg)](https://github.com/ome/ansible-role-postgresql-client/actions)
-[![Ansible Role](https://img.shields.io/badge/ansible--galaxy-postgresql_client-blue.svg)](https://galaxy.ansible.com/ui/standalone/roles/ome/postgresql_client/)
+[![Ansible Role](https://img.shields.io/badge/ansible--galaxy-postgresql-client-blue.svg)](https://galaxy.ansible.com/ui/standalone/roles/ome/postgresql-client/)
 
 Install PostgreSQL clients from the upstream distribution.
 
@@ -26,7 +26,7 @@ Example Playbook
     # which allow access to all users
     - hosts: localhost
       roles:
-      - role: ome.postgresql_client
+      - role: ome.postgresql-client
         postgresql_version: "12"
 
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,7 +13,7 @@ galaxy_info:
       versions:
         - jammy
   namespace: ome
-  role_name: postgresql_client
+  role_name: postgresql-client
   galaxy_tags: ['postgresql', 'database']
 
 dependencies: []

--- a/molecule/resources/playbook.yml
+++ b/molecule/resources/playbook.yml
@@ -2,4 +2,4 @@
 - name: Converge
   hosts: all
   roles:
-    - role: ome.postgresql_client
+    - role: ome.postgresql-client


### PR DESCRIPTION
A new tag was pushed today but the location has now been changed by galaxy see
https://galaxy.ansible.com/ui/standalone/roles/ome/postgresql-client/