### PR TITLE
review the publication

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -55,5 +55,8 @@ jobs:
           name=$(grep 'role_name' meta/main.yml | sed -r 's/^[^:]*:(.*)$/\1/')
           echo "rolename=$name" >> "$GITHUB_OUTPUT"
       - name: Publish to Galaxy
-        run: |
-          ansible-galaxy role import -vvv --api-key ${{ secrets.GALAXY_API_KEY }} --branch ${{  github.ref_name }} --role-name=${{ steps.role-name.outputs.rolename }} ${GITHUB_REPOSITORY%/*} ${GITHUB_REPOSITORY#*/} 
+        uses: ome/action-ansible-galaxy-publish@main
+        with:
+          galaxy-api-key: ${{ secrets.GALAXY_API_KEY }}
+          galaxy-version: ${{  github.ref_name }}
+          role-name: ${{ steps.role-name.outputs.rolename }}

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -48,8 +48,12 @@ jobs:
       - test
     runs-on: ubuntu-22.04
     steps:
-      - name: galaxy
-        uses: ansible-actions/ansible-galaxy-action@v1.2.0
-        with:
-          galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}
-          galaxy_version: ${{  github.ref_name }}
+      - uses: actions/checkout@v4
+      - name: Read the role name
+        id: role-name
+        run: |
+          name=$(grep 'role_name' meta/main.yml | sed -r 's/^[^:]*:(.*)$/\1/')
+          echo "rolename=$name" >> "$GITHUB_OUTPUT"
+      - name: Publish to Galaxy
+        run: |
+          ansible-galaxy role import -vvv --api-key ${{ secrets.GALAXY_API_KEY }} --branch ${{  github.ref_name }} --role-name=${{ steps.role-name.outputs.rolename }} ${GITHUB_REPOSITORY%/*} ${GITHUB_REPOSITORY#*/} 


### PR DESCRIPTION
This PR modifies the publication workflow. It uses the command line directly since I have not found an action allowing us to specify the name since it was previously not ignored if declared in ``meta/main.yml``. See https://github.com/ansible/galaxy/pull/2767/files

The role name is extracted from the ``meta/main.yml`` and specified as a command line argument.
If this approach works, changes should be added to https://github.com/ome/action-ansible-galaxy-publish (repository is currently read-only)

