### PR TITLE
Fix rpm key's URL for arch64

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -9,14 +9,7 @@
 - name: Import a key for postgres (aarch64)
   ansible.builtin.rpm_key:
     state: present
-    key: https://download.postgresql.org/pub/repos/yum/keys/RPM-GPG-KEY-PGDG-AARCH64-RHEL9
-  when: ansible_facts.get('architecture') is search("aarch64")
-
-- name: Import a key for postgres (aarch64) 2
-  ansible.builtin.rpm_key:
-    state: present
-    key:  https://download.postgresql.org/pub/repos/yum/keys/RPM-GPG-KEY-PGDG
-    # key: https://download.postgresql.org/pub/repos/yum/keys/RPM-GPG-KEY-PGDG-AARCH64-RHEL9
+    key: https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-AARCH64-RHEL
   when: ansible_facts.get('architecture') is search("aarch64")
 
 - name: postgres | setup dnf repository for arch64


### PR DESCRIPTION
This PR fixes the URL for the rpm key  for arch64