### PR TITLE
Debian 13 support : remove deprecated apt_key

### DIFF
--- a/molecule/ubuntu2404/molecule.yml
+++ b/molecule/ubuntu2404/molecule.yml
@@ -1,0 +1,43 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+    yamllint .
+    ansible-lint
+    flake8
+platforms:
+  - name: postgresql14
+    image: ubuntu:24.04
+  - name: postgresql15
+    image: ubuntu:24.04
+  - name: postgresql16
+    image: ubuntu:24.04
+  - name: postgresql17
+    image: ubuntu:24.04
+  - name: postgresql18
+    image: ubuntu:24.04
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  inventory:
+    host_vars:
+      postgresql14:
+        postgresql_version: "14"
+      postgresql15:
+        postgresql_version: "15"
+      postgresql16:
+        postgresql_version: "16"
+      postgresql17:
+        postgresql_version: "17"
+      postgresql18:
+        postgresql_version: "18"
+  playbooks:
+    converge: ../resources/playbook.yml
+scenario:
+  name: ubuntu2404
+verifier:
+  name: testinfra
+  directory: ../resources/tests/

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -17,7 +17,7 @@
   become: true
   ansible.builtin.apt_repository:
     codename: "{{ ansible_distribution_release }}"
-    repo: "deb [signed-by=/etc/apt/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt/{{ ansible_distribution_release }}-pgdg main"
+    repo: "deb [signed-by=/etc/apt/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt {{ ansible_distribution_release }}-pgdg main"
 
 - name: Postgres | install client packages
   become: true

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -12,7 +12,6 @@
   ansible.builtin.get_url:
     url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     dest: /etc/apt/keyrings/postgresql.asc
-    state: present
 
 - name: Postgres | setup apt repo
   become: true

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -9,16 +9,16 @@
 
 - name: Postgres | get postgresql apt key
   become: true
-  ansible.builtin.apt_key:
+  ansible.builtin.get_url:
     url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+    dest: /etc/apt/keyrings/postgresql.asc
     state: present
 
 - name: Postgres | setup apt repo
   become: true
   ansible.builtin.apt_repository:
     codename: "{{ ansible_distribution_release }}"
-    repo: deb http://apt.postgresql.org/pub/repos/apt/
-          {{ ansible_distribution_release }}-pgdg main
+    repo: "deb [signed-by=/etc/apt/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt/{{ ansible_distribution_release }}-pgdg main"
 
 - name: Postgres | install client packages
   become: true


### PR DESCRIPTION
This role is not working on Debian 13 because it uses the deprecated `apt_key` command via the `ansible.builtin.apt_key` module.

The fix is rather simple and use the example from the [ansible apt_repository_module documentation](https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/apt_repository_module.html).